### PR TITLE
Denoms inventory check and update, and bug fix

### DIFF
--- a/etc/ATMSS.ATMSSEmulatorStarter.log
+++ b/etc/ATMSS.ATMSSEmulatorStarter.log
@@ -1,29 +1,432 @@
-210410-20:32:40 [INFO] -- 
-210410-20:32:40 [INFO] -- 
-210410-20:32:40 [INFO] -- ============================================================
-210410-20:32:40 [INFO] -- ATMSSStarter: Application Starting...
-210410-20:32:42 [INFO] -- BAMSThreadHandler: starting...
-210410-20:32:42 [INFO] -- TouchDisplayHandler: starting...
-210410-20:32:42 [INFO] -- AdvicePrinterHandler: starting...
-210410-20:32:42 [INFO] -- KeypadHandler: starting...
-210410-20:32:42 [INFO] -- CardReaderHandler: starting...
-210410-20:32:42 [INFO] -- DispenserSlotHandler: starting...
-210410-20:32:42 [INFO] -- BuzzerHandler: starting...
-210410-20:32:42 [INFO] -- DepositSlotHandler: starting...
-210410-20:32:42 [INFO] -- timer: starting...
-210410-20:32:42 [INFO] -- ATMSS: starting...
-210410-20:32:44 [INFO] -- 
-210410-20:32:44 [INFO] -- 
-210410-20:32:44 [INFO] -- ============================================================
-210410-20:32:44 [INFO] -- ATMSSStarter: Application Stopping...
-210410-20:32:44 [INFO] -- timer: received terminate!
-210410-20:32:44 [INFO] -- timer: terminating...
-210410-20:32:44 [INFO] -- BuzzerHandler: terminating...
-210410-20:32:44 [INFO] -- AdvicePrinterHandler: terminating...
-210410-20:32:44 [INFO] -- DispenserSlotHandler: terminating...
-210410-20:32:44 [INFO] -- KeypadHandler: terminating...
-210410-20:32:44 [INFO] -- BAMSThreadHandler: terminating...
-210410-20:32:44 [INFO] -- CardReaderHandler: terminating...
-210410-20:32:44 [INFO] -- TouchDisplayHandler: terminating...
-210410-20:32:44 [INFO] -- DepositSlotHandler: terminating...
-210410-20:32:44 [INFO] -- ATMSS: terminating...
+210410-20:48:17 [INFO] -- 
+210410-20:48:17 [INFO] -- 
+210410-20:48:17 [INFO] -- ============================================================
+210410-20:48:17 [INFO] -- ATMSSStarter: Application Starting...
+210410-20:48:20 [INFO] -- CardReaderHandler: starting...
+210410-20:48:20 [INFO] -- KeypadHandler: starting...
+210410-20:48:20 [INFO] -- BAMSThreadHandler: starting...
+210410-20:48:20 [INFO] -- timer: starting...
+210410-20:48:20 [INFO] -- DispenserSlotHandler: starting...
+210410-20:48:20 [INFO] -- BuzzerHandler: starting...
+210410-20:48:20 [INFO] -- DepositSlotHandler: starting...
+210410-20:48:20 [INFO] -- AdvicePrinterHandler: starting...
+210410-20:48:20 [INFO] -- ATMSS: starting...
+210410-20:48:20 [INFO] -- TouchDisplayHandler: starting...
+210410-20:48:28 [INFO] -- CardReaderHandler: card inserted
+210410-20:48:28 [INFO] -- CardInserted: 4107-7014
+210410-20:48:28 [INFO] -- TouchDisplayHandler: update display -- PIN Required
+210410-20:48:28 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:28 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:32 [INFO] -- KeyPressed: 4
+210410-20:48:32 [INFO] -- ATMSS: 4 is pressed
+210410-20:48:32 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:32 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:32 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:33 [INFO] -- KeyPressed: 0
+210410-20:48:33 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:33 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:33 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:33 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:33 [INFO] -- KeyPressed: 0
+210410-20:48:33 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:33 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:33 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:33 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:33 [INFO] -- KeyPressed: 0
+210410-20:48:33 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:33 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:33 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:33 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:33 [INFO] -- KeyPressed: 0
+210410-20:48:33 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:33 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:33 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:33 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:34 [INFO] -- KeyPressed: 0
+210410-20:48:34 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:34 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:34 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:34 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:34 [INFO] -- KeyPressed: 0
+210410-20:48:34 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:34 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:34 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:34 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:34 [INFO] -- KeyPressed: 0
+210410-20:48:34 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:34 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:34 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:34 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:34 [INFO] -- KeyPressed: 0
+210410-20:48:34 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:34 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:34 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:34 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:35 [INFO] -- KeyPressed: Enter
+210410-20:48:35 [INFO] -- ATMSS: Enter is pressed
+210410-20:48:35 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:35 [INFO] -- ATMSS : verifying cardnum and pin
+210410-20:48:35 [INFO] -- pin: 400000000
+210410-20:48:37 [INFO] -- BAMSThreadHandler : incorrect cardnum or pin!
+210410-20:48:37 [INFO] -- TouchDisplayHandler: Error Message Received: Wrong PIN
+
+Please ensure you enter the right PIN
+210410-20:48:37 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:37 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:37 [INFO] -- BuzzerHandler: alert -- Incorrect pin! Please try again!
+210410-20:48:41 [INFO] -- TouchDisplayHandler: update display -- PIN Required
+210410-20:48:41 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:42 [INFO] -- KeyPressed: 0
+210410-20:48:42 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:42 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:42 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:42 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:42 [INFO] -- KeyPressed: 0
+210410-20:48:42 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:42 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:42 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:42 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:42 [INFO] -- KeyPressed: 0
+210410-20:48:42 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:42 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:42 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:42 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:42 [INFO] -- KeyPressed: 0
+210410-20:48:42 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:42 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:42 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:42 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:42 [INFO] -- KeyPressed: 0
+210410-20:48:42 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:42 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:42 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:42 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:42 [INFO] -- KeyPressed: 0
+210410-20:48:42 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:42 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:42 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:42 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:43 [INFO] -- KeyPressed: 0
+210410-20:48:43 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:43 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:43 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:43 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:43 [INFO] -- KeyPressed: 0
+210410-20:48:43 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:43 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:43 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:43 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:43 [INFO] -- KeyPressed: 0
+210410-20:48:43 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:43 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:43 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:43 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:44 [INFO] -- KeyPressed: Enter
+210410-20:48:44 [INFO] -- ATMSS: Enter is pressed
+210410-20:48:44 [INFO] -- ATMSS : verifying cardnum and pin
+210410-20:48:44 [INFO] -- pin: 000000000
+210410-20:48:44 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:44 [INFO] -- BAMSThreadHandler : incorrect cardnum or pin!
+210410-20:48:44 [INFO] -- TouchDisplayHandler: Error Message Received: Wrong PIN
+
+Please ensure you enter the right PIN
+210410-20:48:44 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:44 [INFO] -- BuzzerHandler: alert -- Incorrect pin! Please try again!
+210410-20:48:44 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:48 [INFO] -- TouchDisplayHandler: update display -- PIN Required
+210410-20:48:48 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:50 [INFO] -- KeyPressed: 0
+210410-20:48:50 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:50 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:50 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:50 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:51 [INFO] -- KeyPressed: 0
+210410-20:48:51 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:51 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:51 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:51 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:51 [INFO] -- KeyPressed: 0
+210410-20:48:51 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:51 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:51 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:51 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:51 [INFO] -- KeyPressed: 0
+210410-20:48:51 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:51 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:51 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:51 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:51 [INFO] -- KeyPressed: 0
+210410-20:48:51 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:51 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:51 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:51 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:51 [INFO] -- KeyPressed: 0
+210410-20:48:51 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:51 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:51 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:51 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:52 [INFO] -- KeyPressed: 0
+210410-20:48:52 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:52 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:52 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:52 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:52 [INFO] -- KeyPressed: 0
+210410-20:48:52 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:52 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:52 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:52 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:52 [INFO] -- KeyPressed: 0
+210410-20:48:52 [INFO] -- ATMSS: 0 is pressed
+210410-20:48:52 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:52 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:48:52 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:53 [INFO] -- KeyPressed: Enter
+210410-20:48:53 [INFO] -- ATMSS: Enter is pressed
+210410-20:48:53 [INFO] -- ATMSS : verifying cardnum and pin
+210410-20:48:53 [INFO] -- pin: 000000000
+210410-20:48:53 [INFO] -- KeypadHandler: alert user-- 
+210410-20:48:53 [INFO] -- BAMSThreadHandler : incorrect cardnum or pin!
+210410-20:48:53 [INFO] -- ATMSS: enter wrong PIN three times, retain the card
+210410-20:48:53 [INFO] -- TouchDisplayHandler: Error Message Received: Card Retained
+210410-20:48:53 [INFO] -- BuzzerHandler: alert -- Incorrect pin thrice! Card retained!
+210410-20:48:53 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:48:53 [INFO] -- CardReaderHandler: card retained
+210410-20:48:57 [INFO] -- TouchDisplayHandler: update display -- Welcome
+210410-20:48:57 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:02 [INFO] -- CardReaderHandler: card inserted
+210410-20:49:02 [INFO] -- CardInserted: 2026-6202
+210410-20:49:02 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:02 [INFO] -- TouchDisplayHandler: update display -- PIN Required
+210410-20:49:02 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:03 [INFO] -- KeyPressed: 0
+210410-20:49:03 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:03 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:03 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:03 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:03 [INFO] -- KeyPressed: 0
+210410-20:49:03 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:03 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:03 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:03 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:03 [INFO] -- KeyPressed: 0
+210410-20:49:03 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:03 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:03 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:03 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:03 [INFO] -- KeyPressed: 0
+210410-20:49:03 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:03 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:03 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:03 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:04 [INFO] -- KeyPressed: 0
+210410-20:49:04 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:04 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:04 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:04 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:04 [INFO] -- KeyPressed: 0
+210410-20:49:04 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:04 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:04 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:04 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:04 [INFO] -- KeyPressed: 0
+210410-20:49:04 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:04 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:04 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:04 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:04 [INFO] -- KeyPressed: 0
+210410-20:49:04 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:04 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:04 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:04 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:04 [INFO] -- KeyPressed: 0
+210410-20:49:04 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:04 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:04 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:04 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:04 [INFO] -- KeyPressed: 0
+210410-20:49:04 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:04 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:05 [INFO] -- KeyPressed: 0
+210410-20:49:05 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:05 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:05 [INFO] -- KeyPressed: 0
+210410-20:49:05 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:05 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:05 [INFO] -- KeyPressed: Enter
+210410-20:49:05 [INFO] -- ATMSS: Enter is pressed
+210410-20:49:05 [INFO] -- ATMSS : verifying cardnum and pin
+210410-20:49:05 [INFO] -- pin: 000000000
+210410-20:49:05 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:05 [INFO] -- BAMSThreadHandler : incorrect cardnum or pin!
+210410-20:49:05 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:05 [INFO] -- BuzzerHandler: alert -- Incorrect pin! Please try again!
+210410-20:49:05 [INFO] -- TouchDisplayHandler: Error Message Received: Wrong PIN
+
+Please ensure you enter the right PIN
+210410-20:49:05 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:07 [INFO] -- KeyPressed: 0
+210410-20:49:07 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:07 [INFO] -- KeyPressed: 0
+210410-20:49:07 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:08 [INFO] -- KeyPressed: 2
+210410-20:49:08 [INFO] -- ATMSS: 2 is pressed
+210410-20:49:09 [INFO] -- TouchDisplayHandler: update display -- PIN Required
+210410-20:49:09 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:13 [INFO] -- KeyPressed: 0
+210410-20:49:13 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:13 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:13 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:13 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:13 [INFO] -- KeyPressed: 0
+210410-20:49:13 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:13 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:13 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:13 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:14 [INFO] -- KeyPressed: 0
+210410-20:49:14 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:14 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:14 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:14 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:14 [INFO] -- KeyPressed: 0
+210410-20:49:14 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:14 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:14 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:14 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:14 [INFO] -- KeyPressed: 0
+210410-20:49:14 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:14 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:14 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:14 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:14 [INFO] -- KeyPressed: 0
+210410-20:49:14 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:14 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:14 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:14 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:14 [INFO] -- KeyPressed: 0
+210410-20:49:14 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:14 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:14 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:14 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:14 [INFO] -- KeyPressed: 0
+210410-20:49:14 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:14 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:14 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:14 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:15 [INFO] -- KeyPressed: 0
+210410-20:49:15 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:15 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:15 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:15 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:15 [INFO] -- KeyPressed: 0
+210410-20:49:15 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:15 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:16 [INFO] -- KeyPressed: .
+210410-20:49:16 [INFO] -- ATMSS: . is pressed
+210410-20:49:16 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:16 [INFO] -- KeyPressed: .
+210410-20:49:16 [INFO] -- ATMSS: . is pressed
+210410-20:49:16 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:17 [INFO] -- KeyPressed: 2
+210410-20:49:17 [INFO] -- ATMSS: 2 is pressed
+210410-20:49:17 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:17 [INFO] -- KeyPressed: 2
+210410-20:49:17 [INFO] -- ATMSS: 2 is pressed
+210410-20:49:17 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:18 [INFO] -- KeyPressed: Enter
+210410-20:49:18 [INFO] -- ATMSS: Enter is pressed
+210410-20:49:18 [INFO] -- ATMSS : verifying cardnum and pin
+210410-20:49:18 [INFO] -- pin: 000000000
+210410-20:49:18 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:18 [INFO] -- BAMSThreadHandler : incorrect cardnum or pin!
+210410-20:49:18 [INFO] -- BuzzerHandler: alert -- Incorrect pin! Please try again!
+210410-20:49:18 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:18 [INFO] -- TouchDisplayHandler: Error Message Received: Wrong PIN
+
+Please ensure you enter the right PIN
+210410-20:49:18 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:20 [INFO] -- Poll: TimesUp 88320 0
+210410-20:49:20 [INFO] -- PollAck: CardReaderHandler is up!
+210410-20:49:20 [INFO] -- PollAck: DepositSlotHandler is up!
+210410-20:49:20 [INFO] -- PollAck: BuzzerHandler is up!
+210410-20:49:20 [INFO] -- PollAck: DispenserSlotHandler is up!
+210410-20:49:20 [INFO] -- PollAck: AdvicePrinterHandler is up!
+210410-20:49:20 [INFO] -- PollAck: TouchDisplayHandler is up!
+210410-20:49:20 [INFO] -- PollAck: KeypadHandler is up!
+210410-20:49:22 [INFO] -- TouchDisplayHandler: update display -- PIN Required
+210410-20:49:22 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:25 [INFO] -- KeyPressed: 0
+210410-20:49:25 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:25 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:25 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:25 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:25 [INFO] -- KeyPressed: 0
+210410-20:49:25 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:25 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:25 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:25 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:25 [INFO] -- KeyPressed: 0
+210410-20:49:25 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:25 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:25 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:25 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:25 [INFO] -- KeyPressed: 0
+210410-20:49:25 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:25 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:25 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:25 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:26 [INFO] -- KeyPressed: 1
+210410-20:49:26 [INFO] -- ATMSS: 1 is pressed
+210410-20:49:26 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:26 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:26 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:26 [INFO] -- KeyPressed: 0
+210410-20:49:26 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:26 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:26 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:26 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:26 [INFO] -- KeyPressed: 0
+210410-20:49:26 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:26 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:26 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:26 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:26 [INFO] -- KeyPressed: 0
+210410-20:49:26 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:26 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:26 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:26 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:27 [INFO] -- KeyPressed: 0
+210410-20:49:27 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:27 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:27 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-20:49:27 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:27 [INFO] -- KeyPressed: 0
+210410-20:49:27 [INFO] -- ATMSS: 0 is pressed
+210410-20:49:27 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:28 [INFO] -- KeyPressed: Enter
+210410-20:49:28 [INFO] -- ATMSS: Enter is pressed
+210410-20:49:28 [INFO] -- ATMSS : verifying cardnum and pin
+210410-20:49:28 [INFO] -- KeypadHandler: alert user-- 
+210410-20:49:28 [INFO] -- pin: 000010000
+210410-20:49:28 [INFO] -- BAMSThreadHandler : incorrect cardnum or pin!
+210410-20:49:28 [INFO] -- ATMSS: enter wrong PIN three times, retain the card
+210410-20:49:28 [INFO] -- TouchDisplayHandler: Error Message Received: Card Retained
+210410-20:49:28 [INFO] -- BuzzerHandler: alert -- Incorrect pin thrice! Card retained!
+210410-20:49:28 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:28 [INFO] -- CardReaderHandler: card retained
+210410-20:49:32 [INFO] -- TouchDisplayHandler: update display -- Welcome
+210410-20:49:32 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-20:49:39 [INFO] -- 
+210410-20:49:39 [INFO] -- 
+210410-20:49:39 [INFO] -- ============================================================
+210410-20:49:39 [INFO] -- ATMSSStarter: Application Stopping...
+210410-20:49:39 [INFO] -- ATMSS: terminating...
+210410-20:49:39 [INFO] -- CardReaderHandler: terminating...
+210410-20:49:39 [INFO] -- BAMSThreadHandler: terminating...
+210410-20:49:39 [INFO] -- KeypadHandler: terminating...
+210410-20:49:39 [INFO] -- AdvicePrinterHandler: terminating...
+210410-20:49:39 [INFO] -- timer: received terminate!
+210410-20:49:39 [INFO] -- timer: terminating...
+210410-20:49:39 [INFO] -- TouchDisplayHandler: terminating...
+210410-20:49:39 [INFO] -- DepositSlotHandler: terminating...
+210410-20:49:39 [INFO] -- DispenserSlotHandler: terminating...
+210410-20:49:39 [INFO] -- BuzzerHandler: terminating...

--- a/etc/ATMSS.ATMSSEmulatorStarter.log
+++ b/etc/ATMSS.ATMSSEmulatorStarter.log
@@ -1,166 +1,176 @@
-210410-17:23:37 [INFO] -- 
-210410-17:23:37 [INFO] -- 
-210410-17:23:37 [INFO] -- ============================================================
-210410-17:23:37 [INFO] -- ATMSSStarter: Application Starting...
-210410-17:23:39 [INFO] -- CardReaderHandler: starting...
-210410-17:23:39 [INFO] -- KeypadHandler: starting...
-210410-17:23:39 [INFO] -- timer: starting...
-210410-17:23:39 [INFO] -- BuzzerHandler: starting...
-210410-17:23:39 [INFO] -- DispenserSlotHandler: starting...
-210410-17:23:39 [INFO] -- ATMSS: starting...
-210410-17:23:39 [INFO] -- DepositSlotHandler: starting...
-210410-17:23:39 [INFO] -- BAMSThreadHandler: starting...
-210410-17:23:39 [INFO] -- TouchDisplayHandler: starting...
-210410-17:23:39 [INFO] -- AdvicePrinterHandler: starting...
-210410-17:23:43 [INFO] -- CardReaderHandler: card inserted
-210410-17:23:43 [INFO] -- CardInserted: 4107-7014
-210410-17:23:43 [INFO] -- KeypadHandler: alert user-- 
-210410-17:23:43 [INFO] -- TouchDisplayHandler: update display -- PIN Required
-210410-17:23:43 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:23:47 [INFO] -- KeyPressed: 4
-210410-17:23:47 [INFO] -- ATMSS: 4 is pressed
-210410-17:23:47 [INFO] -- KeypadHandler: alert user-- 
-210410-17:23:47 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-17:23:47 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:23:47 [INFO] -- KeyPressed: 5
-210410-17:23:47 [INFO] -- ATMSS: 5 is pressed
-210410-17:23:47 [INFO] -- KeypadHandler: alert user-- 
-210410-17:23:47 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-17:23:47 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:23:48 [INFO] -- KeyPressed: 6
-210410-17:23:48 [INFO] -- ATMSS: 6 is pressed
-210410-17:23:48 [INFO] -- KeypadHandler: alert user-- 
-210410-17:23:48 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-17:23:48 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:23:48 [INFO] -- KeyPressed: 1
-210410-17:23:48 [INFO] -- ATMSS: 1 is pressed
-210410-17:23:48 [INFO] -- KeypadHandler: alert user-- 
-210410-17:23:48 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-17:23:48 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:23:49 [INFO] -- KeyPressed: 2
-210410-17:23:49 [INFO] -- ATMSS: 2 is pressed
-210410-17:23:49 [INFO] -- KeypadHandler: alert user-- 
-210410-17:23:49 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-17:23:49 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:23:49 [INFO] -- KeyPressed: 3
-210410-17:23:49 [INFO] -- ATMSS: 3 is pressed
-210410-17:23:49 [INFO] -- KeypadHandler: alert user-- 
-210410-17:23:49 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-17:23:49 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:23:50 [INFO] -- KeyPressed: 7
-210410-17:23:50 [INFO] -- ATMSS: 7 is pressed
-210410-17:23:50 [INFO] -- KeypadHandler: alert user-- 
-210410-17:23:50 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-17:23:50 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:23:50 [INFO] -- KeyPressed: 8
-210410-17:23:50 [INFO] -- ATMSS: 8 is pressed
-210410-17:23:50 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-17:23:50 [INFO] -- KeypadHandler: alert user-- 
-210410-17:23:50 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:23:51 [INFO] -- KeyPressed: 9
-210410-17:23:51 [INFO] -- ATMSS: 9 is pressed
-210410-17:23:51 [INFO] -- KeypadHandler: alert user-- 
-210410-17:23:51 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-17:23:51 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:23:52 [INFO] -- KeyPressed: Enter
-210410-17:23:52 [INFO] -- ATMSS: Enter is pressed
-210410-17:23:52 [INFO] -- ATMSS : verifying cardnum and pin
-210410-17:23:52 [INFO] -- KeypadHandler: alert user-- 
-210410-17:23:52 [INFO] -- pin: 456123789
-210410-17:23:53 [INFO] -- BAMSThreadHandler : successful login!
-210410-17:23:53 [INFO] -- TouchDisplayHandler: changing login status
-210410-17:23:53 [INFO] -- TouchDisplayHandler: select account
-210410-17:23:53 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-17:23:54 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-17:23:54 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-17:23:55 [INFO] -- MouseCLicked: Account Balance Enquiry
-210410-17:23:55 [INFO] -- TouchDisplayHandler: account enquiry
-210410-17:23:55 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-17:23:56 [INFO] -- MouseCLicked: Continue Transaction
-210410-17:23:56 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-17:23:56 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-17:23:57 [INFO] -- MouseCLicked: Cash Deposit
-210410-17:23:57 [INFO] -- TouchDisplayHandler: update display -- Cash Deposit
-210410-17:23:57 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayConfirmation.fxml
-210410-17:23:57 [INFO] -- BuzzerHandler: alert -- Deposit Slot Opened!
-210410-17:23:57 [INFO] -- DepositSlotHandler: alert user-- 
-210410-17:23:57 [INFO] -- DepositSlotHandlerOpening Deposit Slot
-210410-17:24:01 [INFO] -- DepositSlotHandlerClosing Deposit Slot
-210410-17:24:01 [INFO] -- DepositSlotHandlerClosing Deposit Slot
-210410-17:24:01 [INFO] -- CashDeposit Denominations: 3000
-210410-17:24:01 [INFO] -- TouchDisplayHandler: cash deposit
-210410-17:24:01 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayConfirmation.fxml
-210410-17:24:02 [INFO] -- MouseCLicked: Confirm Amount
-210410-17:24:02 [INFO] -- TouchDisplayHandlerCash Deposit Result
-210410-17:24:02 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-17:24:03 [INFO] -- MouseCLicked: Continue Transaction
-210410-17:24:03 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-17:24:03 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-17:24:03 [INFO] -- MouseCLicked: Account Balance Enquiry
-210410-17:24:04 [INFO] -- TouchDisplayHandler: account enquiry
-210410-17:24:04 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-17:24:04 [INFO] -- MouseCLicked: Continue Transaction
-210410-17:24:04 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-17:24:04 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-17:24:05 [INFO] -- MouseCLicked: Cash Withdrawal
-210410-17:24:05 [INFO] -- TouchDisplayHandler: update display -- Cash Withdrawal
-210410-17:24:05 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:24:05 [INFO] -- KeypadHandler: alert user-- 
-210410-17:24:07 [INFO] -- KeyPressed: 1
-210410-17:24:07 [INFO] -- ATMSS: 1 is pressed
-210410-17:24:07 [INFO] -- KeypadHandler: alert user-- 
-210410-17:24:07 [INFO] -- TouchDisplayHandler: Amount Field Change
-210410-17:24:07 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:24:08 [INFO] -- KeyPressed: 00
-210410-17:24:08 [INFO] -- ATMSS: 00 is pressed
-210410-17:24:08 [INFO] -- TouchDisplayHandler: Amount Field Change
-210410-17:24:08 [INFO] -- KeypadHandler: alert user-- 
-210410-17:24:08 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:24:09 [INFO] -- KeyPressed: 0
-210410-17:24:09 [INFO] -- ATMSS: 0 is pressed
-210410-17:24:09 [INFO] -- TouchDisplayHandler: Amount Field Change
-210410-17:24:09 [INFO] -- KeypadHandler: alert user-- 
-210410-17:24:09 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:24:09 [INFO] -- KeyPressed: Enter
-210410-17:24:09 [INFO] -- ATMSS: Enter is pressed
-210410-17:24:09 [INFO] -- KeypadHandler: alert user-- 
-210410-17:24:10 [INFO] -- ATMSS: Cash Dispense: $1000
-210410-17:24:10 [INFO] -- BuzzerHandler: alert -- Dispenser Slot Opening!
-210410-17:24:10 [INFO] -- TouchDisplayHandlercash dispense
-210410-17:24:10 [INFO] -- DispenserSlotHandler: cash dispensed
-210410-17:24:10 [INFO] -- DispenserSlotHandler: denoms inventory: $100: 10000, $500: 10000, $1000: 9999
-210410-17:24:10 [INFO] -- DispenserSlotHandler: Opening Dispenser Slot
-210410-17:24:10 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-17:24:25 [WARNING] -- ATMSS: dispenser time out, $1000 and card 4107-7014 has been retained
-210410-17:24:25 [INFO] -- ATMSS: denoms inventory: $100: 10000 $500: 10000 $1000: 10000
-210410-17:24:25 [INFO] -- CardReaderHandler: card retained
-210410-17:24:25 [INFO] -- TouchDisplayHandler: Error Message Received: Dispenser slot time out
-210410-17:24:25 [INFO] -- DispenserSlotHandler: Closing Dispenser Slot
-210410-17:24:25 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:24:25 [INFO] -- DispenserSlotHandler: denoms increase: 0 0 1
-210410-17:24:25 [INFO] -- DispenserSlotHandler: denoms inventory: $100: 10000, $500: 10000, $1000: 10000
-210410-17:24:29 [INFO] -- TouchDisplayHandler: update display -- Welcome
-210410-17:24:29 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-17:24:39 [INFO] -- Poll: TimesUp 41490 0
-210410-17:24:39 [INFO] -- PollAck: CardReaderHandler is up!
-210410-17:24:39 [INFO] -- PollAck: KeypadHandler is up!
-210410-17:24:39 [INFO] -- PollAck: TouchDisplayHandler is up!
-210410-17:24:39 [INFO] -- PollAck: DepositSlotHandler is up!
-210410-17:24:39 [INFO] -- PollAck: DispenserSlotHandler is up!
-210410-17:24:39 [INFO] -- PollAck: AdvicePrinterHandler is up!
-210410-17:24:39 [INFO] -- PollAck: BuzzerHandler is up!
-210410-17:24:48 [INFO] -- 
-210410-17:24:48 [INFO] -- 
-210410-17:24:48 [INFO] -- ============================================================
-210410-17:24:48 [INFO] -- ATMSSStarter: Application Stopping...
-210410-17:24:48 [INFO] -- ATMSS: terminating...
-210410-17:24:48 [INFO] -- CardReaderHandler: terminating...
-210410-17:24:48 [INFO] -- DepositSlotHandler: terminating...
-210410-17:24:48 [INFO] -- DispenserSlotHandler: terminating...
-210410-17:24:48 [INFO] -- timer: received terminate!
-210410-17:24:48 [INFO] -- timer: terminating...
-210410-17:24:48 [INFO] -- BAMSThreadHandler: terminating...
-210410-17:24:48 [INFO] -- TouchDisplayHandler: terminating...
-210410-17:24:48 [INFO] -- AdvicePrinterHandler: terminating...
-210410-17:24:48 [INFO] -- BuzzerHandler: terminating...
-210410-17:24:48 [INFO] -- KeypadHandler: terminating...
+210410-18:09:30 [INFO] -- 
+210410-18:09:30 [INFO] -- 
+210410-18:09:30 [INFO] -- ============================================================
+210410-18:09:30 [INFO] -- ATMSSStarter: Application Starting...
+210410-18:09:32 [INFO] -- CardReaderHandler: starting...
+210410-18:09:32 [INFO] -- timer: starting...
+210410-18:09:32 [INFO] -- AdvicePrinterHandler: starting...
+210410-18:09:32 [INFO] -- TouchDisplayHandler: starting...
+210410-18:09:32 [INFO] -- KeypadHandler: starting...
+210410-18:09:32 [INFO] -- DispenserSlotHandler: starting...
+210410-18:09:32 [INFO] -- DepositSlotHandler: starting...
+210410-18:09:32 [INFO] -- BAMSThreadHandler: starting...
+210410-18:09:32 [INFO] -- BuzzerHandler: starting...
+210410-18:09:32 [INFO] -- ATMSS: starting...
+210410-18:09:37 [INFO] -- CardReaderHandler: card inserted
+210410-18:09:37 [INFO] -- CardInserted: 4107-7014
+210410-18:09:37 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:37 [INFO] -- TouchDisplayHandler: update display -- PIN Required
+210410-18:09:37 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:09:41 [INFO] -- KeyPressed: 4
+210410-18:09:41 [INFO] -- ATMSS: 4 is pressed
+210410-18:09:41 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:41 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-18:09:41 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:09:42 [INFO] -- KeyPressed: 5
+210410-18:09:42 [INFO] -- ATMSS: 5 is pressed
+210410-18:09:42 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-18:09:42 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:42 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:09:42 [INFO] -- KeyPressed: 6
+210410-18:09:42 [INFO] -- ATMSS: 6 is pressed
+210410-18:09:42 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:42 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-18:09:42 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:09:43 [INFO] -- KeyPressed: 1
+210410-18:09:43 [INFO] -- ATMSS: 1 is pressed
+210410-18:09:43 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:43 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-18:09:43 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:09:43 [INFO] -- KeyPressed: 2
+210410-18:09:43 [INFO] -- ATMSS: 2 is pressed
+210410-18:09:43 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:43 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-18:09:43 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:09:44 [INFO] -- KeyPressed: 3
+210410-18:09:44 [INFO] -- ATMSS: 3 is pressed
+210410-18:09:44 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:44 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-18:09:44 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:09:44 [INFO] -- KeyPressed: 7
+210410-18:09:44 [INFO] -- ATMSS: 7 is pressed
+210410-18:09:44 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:44 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-18:09:44 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:09:45 [INFO] -- KeyPressed: 8
+210410-18:09:45 [INFO] -- ATMSS: 8 is pressed
+210410-18:09:45 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:45 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-18:09:45 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:09:45 [INFO] -- KeyPressed: 9
+210410-18:09:45 [INFO] -- ATMSS: 9 is pressed
+210410-18:09:45 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:45 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-18:09:45 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:09:47 [INFO] -- KeyPressed: Enter
+210410-18:09:47 [INFO] -- ATMSS: Enter is pressed
+210410-18:09:47 [INFO] -- ATMSS : verifying cardnum and pin
+210410-18:09:47 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:47 [INFO] -- pin: 456123789
+210410-18:09:48 [INFO] -- BAMSThreadHandler : successful login!
+210410-18:09:48 [INFO] -- TouchDisplayHandler: changing login status
+210410-18:09:48 [INFO] -- TouchDisplayHandler: select account
+210410-18:09:48 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-18:09:49 [INFO] -- TouchDisplayHandler: update display -- MainMenu
+210410-18:09:49 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-18:09:50 [INFO] -- MouseCLicked: Account Balance Enquiry
+210410-18:09:50 [INFO] -- TouchDisplayHandler: account enquiry
+210410-18:09:50 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-18:09:52 [INFO] -- MouseCLicked: Continue Transaction
+210410-18:09:52 [INFO] -- TouchDisplayHandler: update display -- MainMenu
+210410-18:09:52 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-18:09:54 [INFO] -- MouseCLicked: Cash Withdrawal
+210410-18:09:54 [INFO] -- TouchDisplayHandler: update display -- Cash Withdrawal
+210410-18:09:54 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:54 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:09:59 [INFO] -- KeyPressed: 2
+210410-18:09:59 [INFO] -- ATMSS: 2 is pressed
+210410-18:09:59 [INFO] -- KeypadHandler: alert user-- 
+210410-18:09:59 [INFO] -- TouchDisplayHandler: Amount Field Change
+210410-18:09:59 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:10:00 [INFO] -- KeyPressed: 00
+210410-18:10:00 [INFO] -- ATMSS: 00 is pressed
+210410-18:10:00 [INFO] -- KeypadHandler: alert user-- 
+210410-18:10:00 [INFO] -- TouchDisplayHandler: Amount Field Change
+210410-18:10:00 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:10:00 [INFO] -- KeyPressed: 0
+210410-18:10:00 [INFO] -- ATMSS: 0 is pressed
+210410-18:10:00 [INFO] -- KeypadHandler: alert user-- 
+210410-18:10:00 [INFO] -- TouchDisplayHandler: Amount Field Change
+210410-18:10:00 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:10:01 [INFO] -- KeyPressed: Enter
+210410-18:10:01 [INFO] -- ATMSS: Enter is pressed
+210410-18:10:01 [INFO] -- KeypadHandler: alert user-- 
+210410-18:10:01 [INFO] -- ATMSS: Cash Dispense: $2000
+210410-18:10:01 [INFO] -- TouchDisplayHandlercash dispense
+210410-18:10:01 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-18:10:01 [INFO] -- BuzzerHandler: alert -- Dispenser Slot Opening!
+210410-18:10:01 [INFO] -- DispenserSlotHandler: cash dispensed
+210410-18:10:01 [INFO] -- DispenserSlotHandler: denoms inventory: $100: 10000, $500: 10000, $1000: 9998
+210410-18:10:01 [INFO] -- DispenserSlotHandler: Opening Dispenser Slot
+210410-18:10:06 [INFO] -- DispenserSlotHandler: Closing Dispenser Slot
+210410-18:10:06 [INFO] -- ATMSS: denoms change: decrease: 0 0 2
+210410-18:10:06 [INFO] -- ATMSS: denoms: $100: 10000 $500: 10000 $1000: 9998
+210410-18:10:06 [INFO] -- TouchDisplayHandlercash dispense finish
+210410-18:10:06 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-18:10:08 [INFO] -- MouseCLicked: Continue Transaction
+210410-18:10:08 [INFO] -- TouchDisplayHandler: update display -- MainMenu
+210410-18:10:08 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-18:10:10 [INFO] -- MouseCLicked: Account Balance Enquiry
+210410-18:10:10 [INFO] -- TouchDisplayHandler: account enquiry
+210410-18:10:10 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-18:10:11 [INFO] -- MouseCLicked: Continue Transaction
+210410-18:10:11 [INFO] -- TouchDisplayHandler: update display -- MainMenu
+210410-18:10:11 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-18:10:11 [INFO] -- MouseCLicked: Cash Deposit
+210410-18:10:11 [INFO] -- TouchDisplayHandler: update display -- Cash Deposit
+210410-18:10:11 [INFO] -- BuzzerHandler: alert -- Deposit Slot Opened!
+210410-18:10:11 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayConfirmation.fxml
+210410-18:10:11 [INFO] -- DepositSlotHandler: alert user-- 
+210410-18:10:11 [INFO] -- DepositSlotHandlerOpening Deposit Slot
+210410-18:10:20 [INFO] -- DepositSlotHandlerClosing Deposit Slot
+210410-18:10:20 [INFO] -- CashDeposit Denominations: 3600
+210410-18:10:20 [INFO] -- DepositSlotHandlerClosing Deposit Slot
+210410-18:10:20 [INFO] -- TouchDisplayHandler: cash deposit
+210410-18:10:20 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayConfirmation.fxml
+210410-18:10:21 [INFO] -- MouseCLicked: Confirm Amount
+210410-18:10:22 [INFO] -- ATMSS: denoms change: increase: 1 1 3
+210410-18:10:22 [INFO] -- ATMSS: denoms: $100: 10001 $500: 10001 $1000: 10001
+210410-18:10:22 [INFO] -- DispenserSlotHandler: denoms increase: 1 1 3
+210410-18:10:22 [INFO] -- TouchDisplayHandlerCash Deposit Result
+210410-18:10:22 [INFO] -- DispenserSlotHandler: denoms inventory: $100: 10001, $500: 10001, $1000: 10001
+210410-18:10:22 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-18:10:25 [INFO] -- MouseCLicked: Continue Transaction
+210410-18:10:25 [INFO] -- TouchDisplayHandler: update display -- MainMenu
+210410-18:10:25 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-18:10:26 [INFO] -- MouseCLicked: Account Balance Enquiry
+210410-18:10:27 [INFO] -- TouchDisplayHandler: account enquiry
+210410-18:10:27 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-18:10:32 [INFO] -- MouseCLicked: End Transaction
+210410-18:10:32 [INFO] -- TouchDisplayHandler: update display -- Welcome
+210410-18:10:32 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-18:10:32 [INFO] -- CardReaderHandler: card ejected
+210410-18:10:32 [INFO] -- Poll: TimesUp 73221 0
+210410-18:10:32 [INFO] -- PollAck: TouchDisplayHandler is up!
+210410-18:10:32 [INFO] -- PollAck: DepositSlotHandler is up!
+210410-18:10:32 [INFO] -- PollAck: DispenserSlotHandler is up!
+210410-18:10:32 [INFO] -- PollAck: BuzzerHandler is up!
+210410-18:10:32 [INFO] -- PollAck: AdvicePrinterHandler is up!
+210410-18:10:32 [INFO] -- PollAck: KeypadHandler is up!
+210410-18:10:32 [INFO] -- PollAck: CardReaderHandler is up!
+210410-18:10:43 [INFO] -- CardReaderHandler: card removed
+210410-18:10:46 [INFO] -- 
+210410-18:10:46 [INFO] -- 
+210410-18:10:46 [INFO] -- ============================================================
+210410-18:10:46 [INFO] -- ATMSSStarter: Application Stopping...
+210410-18:10:46 [INFO] -- ATMSS: terminating...
+210410-18:10:46 [INFO] -- CardReaderHandler: terminating...
+210410-18:10:46 [INFO] -- AdvicePrinterHandler: terminating...
+210410-18:10:46 [INFO] -- BAMSThreadHandler: terminating...
+210410-18:10:46 [INFO] -- BuzzerHandler: terminating...
+210410-18:10:46 [INFO] -- timer: received terminate!
+210410-18:10:46 [INFO] -- timer: terminating...
+210410-18:10:46 [INFO] -- KeypadHandler: terminating...
+210410-18:10:46 [INFO] -- DepositSlotHandler: terminating...
+210410-18:10:46 [INFO] -- TouchDisplayHandler: terminating...
+210410-18:10:46 [INFO] -- DispenserSlotHandler: terminating...

--- a/etc/ATMSS.ATMSSEmulatorStarter.log
+++ b/etc/ATMSS.ATMSSEmulatorStarter.log
@@ -1,178 +1,29 @@
-210410-19:38:17 [INFO] -- 
-210410-19:38:17 [INFO] -- 
-210410-19:38:17 [INFO] -- ============================================================
-210410-19:38:17 [INFO] -- ATMSSStarter: Application Starting...
-210410-19:38:25 [INFO] -- timer: starting...
-210410-19:38:25 [INFO] -- AdvicePrinterHandler: starting...
-210410-19:38:25 [INFO] -- BuzzerHandler: starting...
-210410-19:38:25 [INFO] -- BAMSThreadHandler: starting...
-210410-19:38:25 [INFO] -- DispenserSlotHandler: starting...
-210410-19:38:25 [INFO] -- DepositSlotHandler: starting...
-210410-19:38:25 [INFO] -- TouchDisplayHandler: starting...
-210410-19:38:25 [INFO] -- KeypadHandler: starting...
-210410-19:38:25 [INFO] -- CardReaderHandler: starting...
-210410-19:38:25 [INFO] -- ATMSS: starting...
-210410-19:38:52 [INFO] -- CardReaderHandler: card inserted
-210410-19:38:52 [INFO] -- CardInserted: 4107-7014
-210410-19:38:52 [INFO] -- KeypadHandler: alert user-- 
-210410-19:38:52 [INFO] -- TouchDisplayHandler: update display -- PIN Required
-210410-19:38:52 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:05 [INFO] -- KeyPressed: 4
-210410-19:39:05 [INFO] -- ATMSS: 4 is pressed
-210410-19:39:05 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:05 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-19:39:05 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:06 [INFO] -- KeyPressed: 5
-210410-19:39:06 [INFO] -- ATMSS: 5 is pressed
-210410-19:39:06 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:06 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-19:39:06 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:06 [INFO] -- KeyPressed: 6
-210410-19:39:06 [INFO] -- ATMSS: 6 is pressed
-210410-19:39:06 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:06 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-19:39:06 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:07 [INFO] -- KeyPressed: 1
-210410-19:39:07 [INFO] -- ATMSS: 1 is pressed
-210410-19:39:07 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:07 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-19:39:07 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:08 [INFO] -- KeyPressed: 2
-210410-19:39:08 [INFO] -- ATMSS: 2 is pressed
-210410-19:39:08 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:08 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-19:39:08 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:08 [INFO] -- KeyPressed: 3
-210410-19:39:08 [INFO] -- ATMSS: 3 is pressed
-210410-19:39:08 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:08 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-19:39:08 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:09 [INFO] -- KeyPressed: 7
-210410-19:39:09 [INFO] -- ATMSS: 7 is pressed
-210410-19:39:09 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:09 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-19:39:09 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:09 [INFO] -- KeyPressed: 8
-210410-19:39:09 [INFO] -- ATMSS: 8 is pressed
-210410-19:39:09 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:09 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-19:39:09 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:10 [INFO] -- KeyPressed: 9
-210410-19:39:10 [INFO] -- ATMSS: 9 is pressed
-210410-19:39:10 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-19:39:10 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:10 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:11 [INFO] -- KeyPressed: Enter
-210410-19:39:11 [INFO] -- ATMSS: Enter is pressed
-210410-19:39:11 [INFO] -- ATMSS : verifying cardnum and pin
-210410-19:39:11 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:11 [INFO] -- pin: 456123789
-210410-19:39:13 [INFO] -- BAMSThreadHandler : successful login!
-210410-19:39:13 [INFO] -- TouchDisplayHandler: changing login status
-210410-19:39:13 [INFO] -- TouchDisplayHandler: select account
-210410-19:39:13 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-19:39:14 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-19:39:14 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-19:39:15 [INFO] -- MouseCLicked: Account Balance Enquiry
-210410-19:39:15 [INFO] -- TouchDisplayHandler: account enquiry
-210410-19:39:15 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-19:39:16 [INFO] -- MouseCLicked: Continue Transaction
-210410-19:39:16 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-19:39:16 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-19:39:17 [INFO] -- MouseCLicked: Cash Withdrawal
-210410-19:39:17 [INFO] -- TouchDisplayHandler: update display -- Cash Withdrawal
-210410-19:39:17 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:17 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:19 [INFO] -- KeyPressed: 2
-210410-19:39:19 [INFO] -- ATMSS: 2 is pressed
-210410-19:39:19 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:19 [INFO] -- TouchDisplayHandler: Amount Field Change
-210410-19:39:19 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:19 [INFO] -- KeyPressed: 00
-210410-19:39:19 [INFO] -- ATMSS: 00 is pressed
-210410-19:39:19 [INFO] -- TouchDisplayHandler: Amount Field Change
-210410-19:39:19 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:19 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:20 [INFO] -- KeyPressed: 0
-210410-19:39:20 [INFO] -- ATMSS: 0 is pressed
-210410-19:39:20 [INFO] -- TouchDisplayHandler: Amount Field Change
-210410-19:39:20 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:20 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:22 [INFO] -- KeyPressed: Enter
-210410-19:39:22 [INFO] -- ATMSS: Enter is pressed
-210410-19:39:22 [INFO] -- KeypadHandler: alert user-- 
-210410-19:39:22 [INFO] -- ATMSS: Cash Dispense: $2000
-210410-19:39:22 [INFO] -- TouchDisplayHandlercash dispense
-210410-19:39:22 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-19:39:22 [INFO] -- DispenserSlotHandler: cash dispensed
-210410-19:39:22 [INFO] -- DispenserSlotHandler: denoms inventory: $100: 10000, $500: 10000, $1000: 9998
-210410-19:39:22 [INFO] -- DispenserSlotHandler: Opening Dispenser Slot
-210410-19:39:22 [INFO] -- BuzzerHandler: alert -- Dispenser Slot Opening!
-210410-19:39:25 [INFO] -- Poll: TimesUp 49374 0
-210410-19:39:25 [INFO] -- PollAck: KeypadHandler is up!
-210410-19:39:25 [INFO] -- PollAck: DepositSlotHandler is up!
-210410-19:39:25 [INFO] -- PollAck: CardReaderHandler is up!
-210410-19:39:25 [INFO] -- PollAck: BuzzerHandler is up!
-210410-19:39:25 [INFO] -- PollAck: DispenserSlotHandler is up!
-210410-19:39:25 [INFO] -- PollAck: TouchDisplayHandler is up!
-210410-19:39:25 [INFO] -- PollAck: AdvicePrinterHandler is up!
-210410-19:39:26 [INFO] -- ATMSS: denoms change: decrease: 0 0 2
-210410-19:39:26 [INFO] -- ATMSS: denoms: $100: 10000 $500: 10000 $1000: 9998
-210410-19:39:26 [INFO] -- DispenserSlotHandler: Closing Dispenser Slot
-210410-19:39:26 [INFO] -- TouchDisplayHandlercash dispense finish
-210410-19:39:26 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-19:39:26 [INFO] -- DispenserSlotHandler: denoms inventory check
-210410-19:39:28 [INFO] -- MouseCLicked: Continue Transaction
-210410-19:39:28 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-19:39:28 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-19:39:29 [INFO] -- MouseCLicked: Account Balance Enquiry
-210410-19:39:29 [INFO] -- TouchDisplayHandler: account enquiry
-210410-19:39:29 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-19:39:31 [INFO] -- MouseCLicked: Continue Transaction
-210410-19:39:31 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-19:39:31 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-19:39:35 [INFO] -- MouseCLicked: Cash Deposit
-210410-19:39:35 [INFO] -- TouchDisplayHandler: update display -- Cash Deposit
-210410-19:39:35 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayConfirmation.fxml
-210410-19:39:35 [INFO] -- BuzzerHandler: alert -- Deposit Slot Opened!
-210410-19:39:35 [INFO] -- DepositSlotHandler: alert user-- 
-210410-19:39:35 [INFO] -- DepositSlotHandlerOpening Deposit Slot
-210410-19:39:37 [INFO] -- DepositSlotHandlerClosing Deposit Slot
-210410-19:39:37 [INFO] -- CashDeposit Denominations: 1000
-210410-19:39:37 [INFO] -- DepositSlotHandlerClosing Deposit Slot
-210410-19:39:37 [INFO] -- TouchDisplayHandler: cash deposit
-210410-19:39:37 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayConfirmation.fxml
-210410-19:39:39 [INFO] -- MouseCLicked: Confirm Amount
-210410-19:39:39 [INFO] -- ATMSS: denoms change: increase: 0 0 1
-210410-19:39:39 [INFO] -- DispenserSlotHandler: denoms increase: 0 0 1
-210410-19:39:39 [INFO] -- ATMSS: denoms: $100: 10000 $500: 10000 $1000: 9999
-210410-19:39:39 [INFO] -- DispenserSlotHandler: denoms inventory: $100: 10000, $500: 10000, $1000: 9999
-210410-19:39:39 [INFO] -- TouchDisplayHandlerCash Deposit Result
-210410-19:39:39 [INFO] -- DispenserSlotHandler: denoms inventory check
-210410-19:39:39 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-19:39:41 [INFO] -- MouseCLicked: Continue Transaction
-210410-19:39:41 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-19:39:41 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-19:39:42 [INFO] -- MouseCLicked: Account Balance Enquiry
-210410-19:39:43 [INFO] -- TouchDisplayHandler: account enquiry
-210410-19:39:43 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-19:39:45 [INFO] -- MouseCLicked: End Transaction
-210410-19:39:45 [INFO] -- CardReaderHandler: card ejected
-210410-19:39:45 [INFO] -- TouchDisplayHandler: update display -- Welcome
-210410-19:39:45 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-19:39:51 [INFO] -- CardReaderHandler: card removed
-210410-19:39:55 [INFO] -- 
-210410-19:39:55 [INFO] -- 
-210410-19:39:55 [INFO] -- ============================================================
-210410-19:39:55 [INFO] -- ATMSSStarter: Application Stopping...
-210410-19:39:55 [INFO] -- ATMSS: terminating...
-210410-19:39:55 [INFO] -- timer: received terminate!
-210410-19:39:55 [INFO] -- timer: terminating...
-210410-19:39:55 [INFO] -- AdvicePrinterHandler: terminating...
-210410-19:39:55 [INFO] -- BAMSThreadHandler: terminating...
-210410-19:39:55 [INFO] -- KeypadHandler: terminating...
-210410-19:39:55 [INFO] -- DepositSlotHandler: terminating...
-210410-19:39:55 [INFO] -- TouchDisplayHandler: terminating...
-210410-19:39:55 [INFO] -- DispenserSlotHandler: terminating...
-210410-19:39:55 [INFO] -- CardReaderHandler: terminating...
-210410-19:39:55 [INFO] -- BuzzerHandler: terminating...
+210410-20:32:40 [INFO] -- 
+210410-20:32:40 [INFO] -- 
+210410-20:32:40 [INFO] -- ============================================================
+210410-20:32:40 [INFO] -- ATMSSStarter: Application Starting...
+210410-20:32:42 [INFO] -- BAMSThreadHandler: starting...
+210410-20:32:42 [INFO] -- TouchDisplayHandler: starting...
+210410-20:32:42 [INFO] -- AdvicePrinterHandler: starting...
+210410-20:32:42 [INFO] -- KeypadHandler: starting...
+210410-20:32:42 [INFO] -- CardReaderHandler: starting...
+210410-20:32:42 [INFO] -- DispenserSlotHandler: starting...
+210410-20:32:42 [INFO] -- BuzzerHandler: starting...
+210410-20:32:42 [INFO] -- DepositSlotHandler: starting...
+210410-20:32:42 [INFO] -- timer: starting...
+210410-20:32:42 [INFO] -- ATMSS: starting...
+210410-20:32:44 [INFO] -- 
+210410-20:32:44 [INFO] -- 
+210410-20:32:44 [INFO] -- ============================================================
+210410-20:32:44 [INFO] -- ATMSSStarter: Application Stopping...
+210410-20:32:44 [INFO] -- timer: received terminate!
+210410-20:32:44 [INFO] -- timer: terminating...
+210410-20:32:44 [INFO] -- BuzzerHandler: terminating...
+210410-20:32:44 [INFO] -- AdvicePrinterHandler: terminating...
+210410-20:32:44 [INFO] -- DispenserSlotHandler: terminating...
+210410-20:32:44 [INFO] -- KeypadHandler: terminating...
+210410-20:32:44 [INFO] -- BAMSThreadHandler: terminating...
+210410-20:32:44 [INFO] -- CardReaderHandler: terminating...
+210410-20:32:44 [INFO] -- TouchDisplayHandler: terminating...
+210410-20:32:44 [INFO] -- DepositSlotHandler: terminating...
+210410-20:32:44 [INFO] -- ATMSS: terminating...

--- a/etc/ATMSS.ATMSSEmulatorStarter.log
+++ b/etc/ATMSS.ATMSSEmulatorStarter.log
@@ -1,176 +1,178 @@
-210410-18:09:30 [INFO] -- 
-210410-18:09:30 [INFO] -- 
-210410-18:09:30 [INFO] -- ============================================================
-210410-18:09:30 [INFO] -- ATMSSStarter: Application Starting...
-210410-18:09:32 [INFO] -- CardReaderHandler: starting...
-210410-18:09:32 [INFO] -- timer: starting...
-210410-18:09:32 [INFO] -- AdvicePrinterHandler: starting...
-210410-18:09:32 [INFO] -- TouchDisplayHandler: starting...
-210410-18:09:32 [INFO] -- KeypadHandler: starting...
-210410-18:09:32 [INFO] -- DispenserSlotHandler: starting...
-210410-18:09:32 [INFO] -- DepositSlotHandler: starting...
-210410-18:09:32 [INFO] -- BAMSThreadHandler: starting...
-210410-18:09:32 [INFO] -- BuzzerHandler: starting...
-210410-18:09:32 [INFO] -- ATMSS: starting...
-210410-18:09:37 [INFO] -- CardReaderHandler: card inserted
-210410-18:09:37 [INFO] -- CardInserted: 4107-7014
-210410-18:09:37 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:37 [INFO] -- TouchDisplayHandler: update display -- PIN Required
-210410-18:09:37 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:09:41 [INFO] -- KeyPressed: 4
-210410-18:09:41 [INFO] -- ATMSS: 4 is pressed
-210410-18:09:41 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:41 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-18:09:41 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:09:42 [INFO] -- KeyPressed: 5
-210410-18:09:42 [INFO] -- ATMSS: 5 is pressed
-210410-18:09:42 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-18:09:42 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:42 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:09:42 [INFO] -- KeyPressed: 6
-210410-18:09:42 [INFO] -- ATMSS: 6 is pressed
-210410-18:09:42 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:42 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-18:09:42 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:09:43 [INFO] -- KeyPressed: 1
-210410-18:09:43 [INFO] -- ATMSS: 1 is pressed
-210410-18:09:43 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:43 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-18:09:43 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:09:43 [INFO] -- KeyPressed: 2
-210410-18:09:43 [INFO] -- ATMSS: 2 is pressed
-210410-18:09:43 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:43 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-18:09:43 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:09:44 [INFO] -- KeyPressed: 3
-210410-18:09:44 [INFO] -- ATMSS: 3 is pressed
-210410-18:09:44 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:44 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-18:09:44 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:09:44 [INFO] -- KeyPressed: 7
-210410-18:09:44 [INFO] -- ATMSS: 7 is pressed
-210410-18:09:44 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:44 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-18:09:44 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:09:45 [INFO] -- KeyPressed: 8
-210410-18:09:45 [INFO] -- ATMSS: 8 is pressed
-210410-18:09:45 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:45 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-18:09:45 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:09:45 [INFO] -- KeyPressed: 9
-210410-18:09:45 [INFO] -- ATMSS: 9 is pressed
-210410-18:09:45 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:45 [INFO] -- TouchDisplayHandler: update display -- enterPIN
-210410-18:09:45 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:09:47 [INFO] -- KeyPressed: Enter
-210410-18:09:47 [INFO] -- ATMSS: Enter is pressed
-210410-18:09:47 [INFO] -- ATMSS : verifying cardnum and pin
-210410-18:09:47 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:47 [INFO] -- pin: 456123789
-210410-18:09:48 [INFO] -- BAMSThreadHandler : successful login!
-210410-18:09:48 [INFO] -- TouchDisplayHandler: changing login status
-210410-18:09:48 [INFO] -- TouchDisplayHandler: select account
-210410-18:09:48 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-18:09:49 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-18:09:49 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-18:09:50 [INFO] -- MouseCLicked: Account Balance Enquiry
-210410-18:09:50 [INFO] -- TouchDisplayHandler: account enquiry
-210410-18:09:50 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-18:09:52 [INFO] -- MouseCLicked: Continue Transaction
-210410-18:09:52 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-18:09:52 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-18:09:54 [INFO] -- MouseCLicked: Cash Withdrawal
-210410-18:09:54 [INFO] -- TouchDisplayHandler: update display -- Cash Withdrawal
-210410-18:09:54 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:54 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:09:59 [INFO] -- KeyPressed: 2
-210410-18:09:59 [INFO] -- ATMSS: 2 is pressed
-210410-18:09:59 [INFO] -- KeypadHandler: alert user-- 
-210410-18:09:59 [INFO] -- TouchDisplayHandler: Amount Field Change
-210410-18:09:59 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:10:00 [INFO] -- KeyPressed: 00
-210410-18:10:00 [INFO] -- ATMSS: 00 is pressed
-210410-18:10:00 [INFO] -- KeypadHandler: alert user-- 
-210410-18:10:00 [INFO] -- TouchDisplayHandler: Amount Field Change
-210410-18:10:00 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:10:00 [INFO] -- KeyPressed: 0
-210410-18:10:00 [INFO] -- ATMSS: 0 is pressed
-210410-18:10:00 [INFO] -- KeypadHandler: alert user-- 
-210410-18:10:00 [INFO] -- TouchDisplayHandler: Amount Field Change
-210410-18:10:00 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:10:01 [INFO] -- KeyPressed: Enter
-210410-18:10:01 [INFO] -- ATMSS: Enter is pressed
-210410-18:10:01 [INFO] -- KeypadHandler: alert user-- 
-210410-18:10:01 [INFO] -- ATMSS: Cash Dispense: $2000
-210410-18:10:01 [INFO] -- TouchDisplayHandlercash dispense
-210410-18:10:01 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-18:10:01 [INFO] -- BuzzerHandler: alert -- Dispenser Slot Opening!
-210410-18:10:01 [INFO] -- DispenserSlotHandler: cash dispensed
-210410-18:10:01 [INFO] -- DispenserSlotHandler: denoms inventory: $100: 10000, $500: 10000, $1000: 9998
-210410-18:10:01 [INFO] -- DispenserSlotHandler: Opening Dispenser Slot
-210410-18:10:06 [INFO] -- DispenserSlotHandler: Closing Dispenser Slot
-210410-18:10:06 [INFO] -- ATMSS: denoms change: decrease: 0 0 2
-210410-18:10:06 [INFO] -- ATMSS: denoms: $100: 10000 $500: 10000 $1000: 9998
-210410-18:10:06 [INFO] -- TouchDisplayHandlercash dispense finish
-210410-18:10:06 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-18:10:08 [INFO] -- MouseCLicked: Continue Transaction
-210410-18:10:08 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-18:10:08 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-18:10:10 [INFO] -- MouseCLicked: Account Balance Enquiry
-210410-18:10:10 [INFO] -- TouchDisplayHandler: account enquiry
-210410-18:10:10 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-18:10:11 [INFO] -- MouseCLicked: Continue Transaction
-210410-18:10:11 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-18:10:11 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-18:10:11 [INFO] -- MouseCLicked: Cash Deposit
-210410-18:10:11 [INFO] -- TouchDisplayHandler: update display -- Cash Deposit
-210410-18:10:11 [INFO] -- BuzzerHandler: alert -- Deposit Slot Opened!
-210410-18:10:11 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayConfirmation.fxml
-210410-18:10:11 [INFO] -- DepositSlotHandler: alert user-- 
-210410-18:10:11 [INFO] -- DepositSlotHandlerOpening Deposit Slot
-210410-18:10:20 [INFO] -- DepositSlotHandlerClosing Deposit Slot
-210410-18:10:20 [INFO] -- CashDeposit Denominations: 3600
-210410-18:10:20 [INFO] -- DepositSlotHandlerClosing Deposit Slot
-210410-18:10:20 [INFO] -- TouchDisplayHandler: cash deposit
-210410-18:10:20 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayConfirmation.fxml
-210410-18:10:21 [INFO] -- MouseCLicked: Confirm Amount
-210410-18:10:22 [INFO] -- ATMSS: denoms change: increase: 1 1 3
-210410-18:10:22 [INFO] -- ATMSS: denoms: $100: 10001 $500: 10001 $1000: 10001
-210410-18:10:22 [INFO] -- DispenserSlotHandler: denoms increase: 1 1 3
-210410-18:10:22 [INFO] -- TouchDisplayHandlerCash Deposit Result
-210410-18:10:22 [INFO] -- DispenserSlotHandler: denoms inventory: $100: 10001, $500: 10001, $1000: 10001
-210410-18:10:22 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-18:10:25 [INFO] -- MouseCLicked: Continue Transaction
-210410-18:10:25 [INFO] -- TouchDisplayHandler: update display -- MainMenu
-210410-18:10:25 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-18:10:26 [INFO] -- MouseCLicked: Account Balance Enquiry
-210410-18:10:27 [INFO] -- TouchDisplayHandler: account enquiry
-210410-18:10:27 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
-210410-18:10:32 [INFO] -- MouseCLicked: End Transaction
-210410-18:10:32 [INFO] -- TouchDisplayHandler: update display -- Welcome
-210410-18:10:32 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
-210410-18:10:32 [INFO] -- CardReaderHandler: card ejected
-210410-18:10:32 [INFO] -- Poll: TimesUp 73221 0
-210410-18:10:32 [INFO] -- PollAck: TouchDisplayHandler is up!
-210410-18:10:32 [INFO] -- PollAck: DepositSlotHandler is up!
-210410-18:10:32 [INFO] -- PollAck: DispenserSlotHandler is up!
-210410-18:10:32 [INFO] -- PollAck: BuzzerHandler is up!
-210410-18:10:32 [INFO] -- PollAck: AdvicePrinterHandler is up!
-210410-18:10:32 [INFO] -- PollAck: KeypadHandler is up!
-210410-18:10:32 [INFO] -- PollAck: CardReaderHandler is up!
-210410-18:10:43 [INFO] -- CardReaderHandler: card removed
-210410-18:10:46 [INFO] -- 
-210410-18:10:46 [INFO] -- 
-210410-18:10:46 [INFO] -- ============================================================
-210410-18:10:46 [INFO] -- ATMSSStarter: Application Stopping...
-210410-18:10:46 [INFO] -- ATMSS: terminating...
-210410-18:10:46 [INFO] -- CardReaderHandler: terminating...
-210410-18:10:46 [INFO] -- AdvicePrinterHandler: terminating...
-210410-18:10:46 [INFO] -- BAMSThreadHandler: terminating...
-210410-18:10:46 [INFO] -- BuzzerHandler: terminating...
-210410-18:10:46 [INFO] -- timer: received terminate!
-210410-18:10:46 [INFO] -- timer: terminating...
-210410-18:10:46 [INFO] -- KeypadHandler: terminating...
-210410-18:10:46 [INFO] -- DepositSlotHandler: terminating...
-210410-18:10:46 [INFO] -- TouchDisplayHandler: terminating...
-210410-18:10:46 [INFO] -- DispenserSlotHandler: terminating...
+210410-19:38:17 [INFO] -- 
+210410-19:38:17 [INFO] -- 
+210410-19:38:17 [INFO] -- ============================================================
+210410-19:38:17 [INFO] -- ATMSSStarter: Application Starting...
+210410-19:38:25 [INFO] -- timer: starting...
+210410-19:38:25 [INFO] -- AdvicePrinterHandler: starting...
+210410-19:38:25 [INFO] -- BuzzerHandler: starting...
+210410-19:38:25 [INFO] -- BAMSThreadHandler: starting...
+210410-19:38:25 [INFO] -- DispenserSlotHandler: starting...
+210410-19:38:25 [INFO] -- DepositSlotHandler: starting...
+210410-19:38:25 [INFO] -- TouchDisplayHandler: starting...
+210410-19:38:25 [INFO] -- KeypadHandler: starting...
+210410-19:38:25 [INFO] -- CardReaderHandler: starting...
+210410-19:38:25 [INFO] -- ATMSS: starting...
+210410-19:38:52 [INFO] -- CardReaderHandler: card inserted
+210410-19:38:52 [INFO] -- CardInserted: 4107-7014
+210410-19:38:52 [INFO] -- KeypadHandler: alert user-- 
+210410-19:38:52 [INFO] -- TouchDisplayHandler: update display -- PIN Required
+210410-19:38:52 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:05 [INFO] -- KeyPressed: 4
+210410-19:39:05 [INFO] -- ATMSS: 4 is pressed
+210410-19:39:05 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:05 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-19:39:05 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:06 [INFO] -- KeyPressed: 5
+210410-19:39:06 [INFO] -- ATMSS: 5 is pressed
+210410-19:39:06 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:06 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-19:39:06 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:06 [INFO] -- KeyPressed: 6
+210410-19:39:06 [INFO] -- ATMSS: 6 is pressed
+210410-19:39:06 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:06 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-19:39:06 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:07 [INFO] -- KeyPressed: 1
+210410-19:39:07 [INFO] -- ATMSS: 1 is pressed
+210410-19:39:07 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:07 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-19:39:07 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:08 [INFO] -- KeyPressed: 2
+210410-19:39:08 [INFO] -- ATMSS: 2 is pressed
+210410-19:39:08 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:08 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-19:39:08 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:08 [INFO] -- KeyPressed: 3
+210410-19:39:08 [INFO] -- ATMSS: 3 is pressed
+210410-19:39:08 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:08 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-19:39:08 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:09 [INFO] -- KeyPressed: 7
+210410-19:39:09 [INFO] -- ATMSS: 7 is pressed
+210410-19:39:09 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:09 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-19:39:09 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:09 [INFO] -- KeyPressed: 8
+210410-19:39:09 [INFO] -- ATMSS: 8 is pressed
+210410-19:39:09 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:09 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-19:39:09 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:10 [INFO] -- KeyPressed: 9
+210410-19:39:10 [INFO] -- ATMSS: 9 is pressed
+210410-19:39:10 [INFO] -- TouchDisplayHandler: update display -- enterPIN
+210410-19:39:10 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:10 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:11 [INFO] -- KeyPressed: Enter
+210410-19:39:11 [INFO] -- ATMSS: Enter is pressed
+210410-19:39:11 [INFO] -- ATMSS : verifying cardnum and pin
+210410-19:39:11 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:11 [INFO] -- pin: 456123789
+210410-19:39:13 [INFO] -- BAMSThreadHandler : successful login!
+210410-19:39:13 [INFO] -- TouchDisplayHandler: changing login status
+210410-19:39:13 [INFO] -- TouchDisplayHandler: select account
+210410-19:39:13 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-19:39:14 [INFO] -- TouchDisplayHandler: update display -- MainMenu
+210410-19:39:14 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-19:39:15 [INFO] -- MouseCLicked: Account Balance Enquiry
+210410-19:39:15 [INFO] -- TouchDisplayHandler: account enquiry
+210410-19:39:15 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-19:39:16 [INFO] -- MouseCLicked: Continue Transaction
+210410-19:39:16 [INFO] -- TouchDisplayHandler: update display -- MainMenu
+210410-19:39:16 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-19:39:17 [INFO] -- MouseCLicked: Cash Withdrawal
+210410-19:39:17 [INFO] -- TouchDisplayHandler: update display -- Cash Withdrawal
+210410-19:39:17 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:17 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:19 [INFO] -- KeyPressed: 2
+210410-19:39:19 [INFO] -- ATMSS: 2 is pressed
+210410-19:39:19 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:19 [INFO] -- TouchDisplayHandler: Amount Field Change
+210410-19:39:19 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:19 [INFO] -- KeyPressed: 00
+210410-19:39:19 [INFO] -- ATMSS: 00 is pressed
+210410-19:39:19 [INFO] -- TouchDisplayHandler: Amount Field Change
+210410-19:39:19 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:19 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:20 [INFO] -- KeyPressed: 0
+210410-19:39:20 [INFO] -- ATMSS: 0 is pressed
+210410-19:39:20 [INFO] -- TouchDisplayHandler: Amount Field Change
+210410-19:39:20 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:20 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:22 [INFO] -- KeyPressed: Enter
+210410-19:39:22 [INFO] -- ATMSS: Enter is pressed
+210410-19:39:22 [INFO] -- KeypadHandler: alert user-- 
+210410-19:39:22 [INFO] -- ATMSS: Cash Dispense: $2000
+210410-19:39:22 [INFO] -- TouchDisplayHandlercash dispense
+210410-19:39:22 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-19:39:22 [INFO] -- DispenserSlotHandler: cash dispensed
+210410-19:39:22 [INFO] -- DispenserSlotHandler: denoms inventory: $100: 10000, $500: 10000, $1000: 9998
+210410-19:39:22 [INFO] -- DispenserSlotHandler: Opening Dispenser Slot
+210410-19:39:22 [INFO] -- BuzzerHandler: alert -- Dispenser Slot Opening!
+210410-19:39:25 [INFO] -- Poll: TimesUp 49374 0
+210410-19:39:25 [INFO] -- PollAck: KeypadHandler is up!
+210410-19:39:25 [INFO] -- PollAck: DepositSlotHandler is up!
+210410-19:39:25 [INFO] -- PollAck: CardReaderHandler is up!
+210410-19:39:25 [INFO] -- PollAck: BuzzerHandler is up!
+210410-19:39:25 [INFO] -- PollAck: DispenserSlotHandler is up!
+210410-19:39:25 [INFO] -- PollAck: TouchDisplayHandler is up!
+210410-19:39:25 [INFO] -- PollAck: AdvicePrinterHandler is up!
+210410-19:39:26 [INFO] -- ATMSS: denoms change: decrease: 0 0 2
+210410-19:39:26 [INFO] -- ATMSS: denoms: $100: 10000 $500: 10000 $1000: 9998
+210410-19:39:26 [INFO] -- DispenserSlotHandler: Closing Dispenser Slot
+210410-19:39:26 [INFO] -- TouchDisplayHandlercash dispense finish
+210410-19:39:26 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-19:39:26 [INFO] -- DispenserSlotHandler: denoms inventory check
+210410-19:39:28 [INFO] -- MouseCLicked: Continue Transaction
+210410-19:39:28 [INFO] -- TouchDisplayHandler: update display -- MainMenu
+210410-19:39:28 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-19:39:29 [INFO] -- MouseCLicked: Account Balance Enquiry
+210410-19:39:29 [INFO] -- TouchDisplayHandler: account enquiry
+210410-19:39:29 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-19:39:31 [INFO] -- MouseCLicked: Continue Transaction
+210410-19:39:31 [INFO] -- TouchDisplayHandler: update display -- MainMenu
+210410-19:39:31 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-19:39:35 [INFO] -- MouseCLicked: Cash Deposit
+210410-19:39:35 [INFO] -- TouchDisplayHandler: update display -- Cash Deposit
+210410-19:39:35 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayConfirmation.fxml
+210410-19:39:35 [INFO] -- BuzzerHandler: alert -- Deposit Slot Opened!
+210410-19:39:35 [INFO] -- DepositSlotHandler: alert user-- 
+210410-19:39:35 [INFO] -- DepositSlotHandlerOpening Deposit Slot
+210410-19:39:37 [INFO] -- DepositSlotHandlerClosing Deposit Slot
+210410-19:39:37 [INFO] -- CashDeposit Denominations: 1000
+210410-19:39:37 [INFO] -- DepositSlotHandlerClosing Deposit Slot
+210410-19:39:37 [INFO] -- TouchDisplayHandler: cash deposit
+210410-19:39:37 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayConfirmation.fxml
+210410-19:39:39 [INFO] -- MouseCLicked: Confirm Amount
+210410-19:39:39 [INFO] -- ATMSS: denoms change: increase: 0 0 1
+210410-19:39:39 [INFO] -- DispenserSlotHandler: denoms increase: 0 0 1
+210410-19:39:39 [INFO] -- ATMSS: denoms: $100: 10000 $500: 10000 $1000: 9999
+210410-19:39:39 [INFO] -- DispenserSlotHandler: denoms inventory: $100: 10000, $500: 10000, $1000: 9999
+210410-19:39:39 [INFO] -- TouchDisplayHandlerCash Deposit Result
+210410-19:39:39 [INFO] -- DispenserSlotHandler: denoms inventory check
+210410-19:39:39 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-19:39:41 [INFO] -- MouseCLicked: Continue Transaction
+210410-19:39:41 [INFO] -- TouchDisplayHandler: update display -- MainMenu
+210410-19:39:41 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-19:39:42 [INFO] -- MouseCLicked: Account Balance Enquiry
+210410-19:39:43 [INFO] -- TouchDisplayHandler: account enquiry
+210410-19:39:43 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayMainMenu.fxml
+210410-19:39:45 [INFO] -- MouseCLicked: End Transaction
+210410-19:39:45 [INFO] -- CardReaderHandler: card ejected
+210410-19:39:45 [INFO] -- TouchDisplayHandler: update display -- Welcome
+210410-19:39:45 [INFO] -- TouchDisplayHandler: loading fxml: TouchDisplayEmulator.fxml
+210410-19:39:51 [INFO] -- CardReaderHandler: card removed
+210410-19:39:55 [INFO] -- 
+210410-19:39:55 [INFO] -- 
+210410-19:39:55 [INFO] -- ============================================================
+210410-19:39:55 [INFO] -- ATMSSStarter: Application Stopping...
+210410-19:39:55 [INFO] -- ATMSS: terminating...
+210410-19:39:55 [INFO] -- timer: received terminate!
+210410-19:39:55 [INFO] -- timer: terminating...
+210410-19:39:55 [INFO] -- AdvicePrinterHandler: terminating...
+210410-19:39:55 [INFO] -- BAMSThreadHandler: terminating...
+210410-19:39:55 [INFO] -- KeypadHandler: terminating...
+210410-19:39:55 [INFO] -- DepositSlotHandler: terminating...
+210410-19:39:55 [INFO] -- TouchDisplayHandler: terminating...
+210410-19:39:55 [INFO] -- DispenserSlotHandler: terminating...
+210410-19:39:55 [INFO] -- CardReaderHandler: terminating...
+210410-19:39:55 [INFO] -- BuzzerHandler: terminating...

--- a/src/ATMSS/ATMSS/ATMSS.java
+++ b/src/ATMSS/ATMSS/ATMSS.java
@@ -263,6 +263,7 @@ public class ATMSS extends AppThread {
                                 touchDisplayMBox.send(new Msg(id, mbox, Msg.Type.TD_UpdateDisplay, "Welcome"));
                                 allReset();
                             } else {
+                                getPin = true;
                                 touchDisplayMBox.send(new Msg(id, mbox, Msg.Type.TD_UpdateDisplay, "PIN Required"));
                             }
                             break;
@@ -321,6 +322,7 @@ public class ATMSS extends AppThread {
 
                 log.info(id + " : verifying cardnum and pin");
                 bamsThreadMBox.send(new Msg(id, mbox, Msg.Type.Verify, cardNum + " " + pin));
+                getPin = false;
 
                 log.info("pin: " + pin);
                 //send variables cardNum and pin to BAMS for login
@@ -373,6 +375,7 @@ public class ATMSS extends AppThread {
                 } else if (transaction.equals("Money Transfer")) {
                     bamsThreadMBox.send(new Msg(id, mbox, Msg.Type.MoneyTransferRequest, cardNum + " " + selectedAcc + " " + transferAcc + " " + amountTyped));
                 }
+                getAmount = false;
             } else {
                 switch (msg.getDetails()) {
                     case "1":

--- a/src/ATMSS/ATMSS/ATMSS.java
+++ b/src/ATMSS/ATMSS/ATMSS.java
@@ -153,7 +153,7 @@ public class ATMSS extends AppThread {
                     log.info(id + ": Cash Dispense: $" + msg.getDetails());
                     amountTyped = msg.getDetails();
                     String amountDispense = denomDispenseCalculate(msg.getDetails());
-                    denomsToChange = amountDispense;
+                    denomsToChange = amountDispense;        //format: "0 0 0"
                     DispenserSlotMBox.send(new Msg(id, mbox, Msg.Type.Denom_sum, amountDispense));        //process the notes to dispense
                     BuzzerMBox.send(new Msg(id, mbox, Msg.Type.Alert, "Dispenser Slot Opening!"));
                     dispenseTimerID = Timer.setTimer(id, mbox, 15000);
@@ -180,6 +180,7 @@ public class ATMSS extends AppThread {
 
                 case Denom_sum:         //receive cash from deposit slot
                     //receive money notes, update the money notes inventory
+                    denomsToChange = msg.getDetails();
                     String[] denom = msg.getDetails().split(" ");
                     amountTyped = (Integer.parseInt(denom[0]) * 100 + Integer.parseInt(denom[1]) * 500 + Integer.parseInt(denom[2]) * 1000) + "";
                     log.info("CashDeposit Denominations: " + amountTyped);
@@ -189,6 +190,12 @@ public class ATMSS extends AppThread {
 
                 case DepositResult:     //receive deposit result from BAMS
                     amountTyped = msg.getDetails();
+                    if ((int) Double.parseDouble(amountTyped) > -1) {
+                        updateDenomsInventory(denomsToChange, true);
+                        DispenserSlotMBox.send(new Msg(id, mbox, Msg.Type.DenomsInventoryUpdate, denomsToChange));
+                        log.info(id + ": denoms change: increase: " + denomsToChange);
+                        log.info(id + ": denoms: $100: " + denom100 + " $500: " + denom500 + " $1000: " + denom1000);
+                    }
                     touchDisplayMBox.send(new Msg(id, mbox, Msg.Type.DepositResult, msg.getDetails()));
                     break;
 

--- a/src/ATMSS/ATMSS/ATMSS.java
+++ b/src/ATMSS/ATMSS/ATMSS.java
@@ -191,8 +191,8 @@ public class ATMSS extends AppThread {
                 case DepositResult:     //receive deposit result from BAMS
                     amountTyped = msg.getDetails();
                     if ((int) Double.parseDouble(amountTyped) > -1) {
-                        updateDenomsInventory(denomsToChange, true);
                         DispenserSlotMBox.send(new Msg(id, mbox, Msg.Type.DenomsInventoryUpdate, denomsToChange));
+                        updateDenomsInventory(denomsToChange, true);
                         log.info(id + ": denoms change: increase: " + denomsToChange);
                         log.info(id + ": denoms: $100: " + denom100 + " $500: " + denom500 + " $1000: " + denom1000);
                     }
@@ -238,6 +238,17 @@ public class ATMSS extends AppThread {
 
                 case Terminate:
                     quit = true;
+                    break;
+
+                case DenomsInventoryCheck:
+                    String denomsKeeping = denom100 + " " + denom500 + " " + denom1000;
+                    if (!denomsKeeping.equals(msg.getDetails())) {
+                        StringTokenizer denomsToken = new StringTokenizer(msg.getDetails());
+                        denom100 = Integer.parseInt(denomsToken.nextToken());
+                        denom500 = Integer.parseInt(denomsToken.nextToken());
+                        denom1000 = Integer.parseInt(denomsToken.nextToken());
+                        log.warning(id + ": Denoms inventory keeping incorrect");
+                    }
                     break;
 
                 case Error:     //receive error that cannot fix by itself
@@ -610,6 +621,7 @@ public class ATMSS extends AppThread {
                 count++;
             }
         }
+        DispenserSlotMBox.send(new Msg(id, mbox, Msg.Type.DenomsInventoryCheck, ""));
     }
 
 }

--- a/src/ATMSS/CardReaderHandler/Emulator/CardReaderEmulator.fxml
+++ b/src/ATMSS/CardReaderHandler/Emulator/CardReaderEmulator.fxml
@@ -35,7 +35,7 @@
 		</AnchorPane>
 		<AnchorPane prefHeight="30.0" AnchorPane.leftAnchor="20.0" AnchorPane.rightAnchor="20.0" AnchorPane.bottomAnchor="20.0">
 			<children>
-			<TextField fx:id="cardStatusField" editable="false" AnchorPane.leftAnchor="0" AnchorPane.rightAnchor="0" />
+			<TextField fx:id="cardStatusField" editable="false" AnchorPane.leftAnchor="0" AnchorPane.rightAnchor="0" text="Card Reader Empty"/>
 			</children>
 		</AnchorPane>
     </children>

--- a/src/ATMSS/CardReaderHandler/Emulator/CardReaderEmulatorController.java
+++ b/src/ATMSS/CardReaderHandler/Emulator/CardReaderEmulatorController.java
@@ -78,21 +78,27 @@ public class CardReaderEmulatorController {
 
         switch (btn.getText()) {
             case "Card 1":
-                defaultCardSelected = btn;
+                if (cardStatusField.getText().equals("Card Reader Empty")) {
+                    defaultCardSelected = btn;
+                }
                 String cardNum1 = appKickstarter.getProperty("CardReader.Card1");
                 cardNumField1.setText(cardNum1.substring(0,4));
                 cardNumField2.setText(cardNum1.substring(5,9));
                 break;
 
             case "Card 2":
-                defaultCardSelected = btn;
+                if (cardStatusField.getText().equals("Card Reader Empty")) {
+                    defaultCardSelected = btn;
+                }
                 String cardNum2 = appKickstarter.getProperty("CardReader.Card2");
                 cardNumField1.setText(cardNum2.substring(0,4));
                 cardNumField2.setText(cardNum2.substring(5,9));
                 break;
 
             case "Card 3":
-                defaultCardSelected = btn;
+                if (cardStatusField.getText().equals("Card Reader Empty")) {
+                    defaultCardSelected = btn;
+                }
                 String cardNum3 = appKickstarter.getProperty("CardReader.Card3");
                 cardNumField1.setText(cardNum3.substring(0,4));
                 cardNumField2.setText(cardNum3.substring(5,9));
@@ -101,6 +107,9 @@ public class CardReaderEmulatorController {
             case "Reset":
                 cardNumField1.setText("");
                 cardNumField2.setText("");
+                if (cardStatusField.getText().equals("Card Reader Empty")) {
+                    defaultCardSelected = null;
+                }
                 break;
 
             case "Insert Card":
@@ -137,9 +146,9 @@ public class CardReaderEmulatorController {
                 }
 
                 // Confirm that card button can be pressed even if the card is removed.
-                card1Btn.setDisable(false);
-                card2Btn.setDisable(false);
-                card3Btn.setDisable(false);
+//                card1Btn.setDisable(false);
+//                card2Btn.setDisable(false);
+//                card3Btn.setDisable(false);
 
                 break;
 

--- a/src/ATMSS/CardReaderHandler/Emulator/CardReaderEmulatorController.java
+++ b/src/ATMSS/CardReaderHandler/Emulator/CardReaderEmulatorController.java
@@ -3,17 +3,14 @@ package ATMSS.CardReaderHandler.Emulator;
 import AppKickstarter.AppKickstarter;
 import AppKickstarter.misc.MBox;
 import AppKickstarter.misc.Msg;
-
-import java.util.ArrayList;
-import java.util.logging.Logger;
-
 import javafx.event.ActionEvent;
-import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyEvent;
-import javafx.scene.layout.StackPane;
+
+import java.util.ArrayList;
+import java.util.logging.Logger;
 
 
 //======================================================================

--- a/src/ATMSS/DispenserSlotHandler/DispenserSlotHandler.java
+++ b/src/ATMSS/DispenserSlotHandler/DispenserSlotHandler.java
@@ -30,6 +30,18 @@ public class DispenserSlotHandler extends HWHandler {
                 handleDenomsUpdate(msg.getDetails());
                 break;
 
+            case DenomsInventoryCheck:
+                if (msg.getDetails().equals("")) {
+                    handleDenomsInventoryCheck();
+                } else {
+                    atmss.send(new Msg(id, mbox, Msg.Type.DenomsInventoryCheck, msg.getDetails()));
+                }
+                break;
+
+            case Error:
+                atmss.send(new Msg(id, mbox, Msg.Type.Error, msg.getDetails()));
+                break;
+
             default:
                 log.warning(id + ": unknown message type: [" + msg + "]");
         }
@@ -49,5 +61,9 @@ public class DispenserSlotHandler extends HWHandler {
 
     protected void handleDenomsUpdate(String details) {
         log.info(id + ": denoms increase: " + details);
+    }
+
+    protected void handleDenomsInventoryCheck() {
+        log.info(id + ": denoms inventory check");
     }
 }

--- a/src/ATMSS/DispenserSlotHandler/Emulator/DispenserSlotEmulator.java
+++ b/src/ATMSS/DispenserSlotHandler/Emulator/DispenserSlotEmulator.java
@@ -74,4 +74,9 @@ public class DispenserSlotEmulator extends DispenserSlotHandler {
         super.handleDenomsUpdate(details);
         DispenserSlotEmulatorController.updateDenomsInventory(details, true);
     }
+
+    protected void handleDenomsInventoryCheck() {
+        super.handleDenomsInventoryCheck();
+        DispenserSlotEmulatorController.checkDenomsInventory();
+    }
 }

--- a/src/ATMSS/DispenserSlotHandler/Emulator/DispenserSlotEmulatorController.java
+++ b/src/ATMSS/DispenserSlotHandler/Emulator/DispenserSlotEmulatorController.java
@@ -123,7 +123,16 @@ public class DispenserSlotEmulatorController {
     }
 
     protected void checkDenomsInventory() {
-
+        DispenserSlotMBox.send(new Msg(id, DispenserSlotMBox, Msg.Type.DenomsInventoryCheck, "" + denom100 + " " + denom500 + " " + denom1000));
+        if (denom100 <= 0) {
+            DispenserSlotMBox.send(new Msg(id, DispenserSlotMBox, Msg.Type.Error, "run out of $100 money notes"));
+        }
+        if (denom500 <= 0) {
+            DispenserSlotMBox.send(new Msg(id, DispenserSlotMBox, Msg.Type.Error, "run out of $500 money notes"));
+        }
+        if (denom1000 <= 0) {
+            DispenserSlotMBox.send(new Msg(id, DispenserSlotMBox, Msg.Type.Error, "run out of $1000 money notes"));
+        }
     }
 
     //check inventory is needed

--- a/src/AppKickstarter/misc/Msg.java
+++ b/src/AppKickstarter/misc/Msg.java
@@ -118,5 +118,6 @@ public class Msg {
         /** Receive Money Transfer Result*/     MoneyTransferResult,
         /** Cash Dispense has been taken */     DispenseFinish,
         /** Update denoms inventory */          DenomsInventoryUpdate,
+        /** Denoms inventory check */       DenomsInventoryCheck,
     } // Type
 } // Msg


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/72689144/114272068-1b852c00-9a47-11eb-9be8-d2eea37fcfc2.png)
Making this change, because this will unlock the card that supposes to be retained
For the problem locking the other card, this probably due to the defaultCardSelected targeting a wrong button. This can be caused by the user pressing the card button after card insertion. This problem should be fixed now. 